### PR TITLE
Include a teardown callback

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,16 @@ test('bar', async t => {
 
   t.equal(await bar, 'bar')
 })
+
+test('teardown', async (t, tearDown) => {
+  tearDown(async () => {
+    console.log('it was executed after the test ends')
+  })
+
+  const bar = Promise.resolve('bar')
+
+  t.equal(await bar, 'bar')
+})
 ```
 
 ### `npm test` away!

--- a/readme.md
+++ b/readme.md
@@ -52,9 +52,9 @@ test('bar', async t => {
   t.equal(await bar, 'bar')
 })
 
-test('teardown', async (t, tearDown) => {
-  tearDown(async () => {
-    console.log('it was executed after the test ends')
+test('teardown example', async (t, teardown) => {
+  teardown(async () => {
+    console.log('it was executed after the test has ended')
   })
 
   const bar = Promise.resolve('bar')

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -11,91 +11,115 @@ function resolveAfter (time) {
 }
 
 test('equal pass', t => t.equal('a', 'a'))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, true)
     assert.strict.equal(title, 'equal pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('equal fail', t => t.equal('a', 'b'))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, false)
     assert.strict.equal(title, 'equal fail')
-    assert.strict.equal(location, 'test.mjs:22')
+    assert.strict.equal(location, 'test.mjs:23')
     assert.strict.equal(message.split('\n').length, 2)
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('ok pass', t => t.ok(true))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, true)
     assert.strict.equal(title, 'ok pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('ok fail', t => t.ok(false))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, false)
     assert.strict.equal(title, 'ok fail')
-    assert.strict.equal(location, 'test.mjs:40')
+    assert.strict.equal(location, 'test.mjs:43')
     assert.strict.equal(message.split('\n').length, 1)
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('deepEqual pass', t => t.deepEqual({ a: { b: 42 } }, { a: { b: 42 } }))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, true)
     assert.strict.equal(title, 'deepEqual pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('deepEqual fail', t => t.deepEqual({ a: { b: 42 } }, { a: { B: 42 } }))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, false)
     assert.strict.equal(title, 'deepEqual fail')
-    assert.strict.equal(location, 'test.mjs:58')
+    assert.strict.equal(location, 'test.mjs:63')
     assert.strict.equal(message.split('\n').length, 6)
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('async pass', async t => t.equal(await resolveAfter(500), 'resolved'))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, true)
     assert.strict.equal(title, 'async pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('async fail', async t => t.equal(await resolveAfter(777), ''))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, false)
     assert.strict.equal(title, 'async fail')
-    assert.strict.equal(location, 'test.mjs:76')
+    assert.strict.equal(location, 'test.mjs:83')
     assert.strict.equal(message.split('\n').length, 2)
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('promise pass', t => resolveAfter(100).then(result => t.equal(result, 'resolved')))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, true)
     assert.strict.equal(title, 'promise pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
 
 test('promise fail', t => resolveAfter(100).then(result => t.equal(result, '')))
-  .then(({ didPass, title, location, message }) => {
+  .then(({ didPass, title, location, message, teardownCalled }) => {
     assert.strict.equal(didPass, false)
     assert.strict.equal(title, 'promise fail')
-    assert.strict.equal(location, 'test.mjs:94')
+    assert.strict.equal(location, 'test.mjs:103')
     assert.strict.equal(message.split('\n').length, 2)
+    assert.strict.equal(teardownCalled, false)
   })
   .catch(e => fail(e))
+
+test('teardown called', (t, teardown) => {
+  const checkings = {}
+  teardown(() => {
+    checkings.teardownCalled = true;
+  });
+})
+.then(({ didPass, title, location, message, teardownCalled }) => {
+  assert.strict.equal(didPass, true)
+  assert.strict.equal(title, 'teardown called')
+  assert.strict.equal(location, '')
+  assert.strict.equal(message, '')
+  assert.strict.equal(teardownCalled, true)
+})


### PR DESCRIPTION
Please consider merging or implement similar logic.

I need a teardown callback to close asynchronous services after each test execution.

```
test('sample teardown', async (t, teardown) => {
  app = App()
  teardown(async () => { app.close() }
 
  // some tests and checkings
  // some tests and checkings
  // teardown will be called even the test fails
})  


```