### PR TITLE
Allow users to pass files on the CLI

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -4,7 +4,11 @@ import concise from './report-concise.mjs'
 import verbose from './report-verbose.mjs'
 import crawl from './crawler.mjs'
 
-crawl('./test/')
+const eventualFiles = process.argv.length > 2
+  ? Promise.resolve(process.argv.slice(2))
+  : crawl('./test/')
+
+eventualFiles
   .then(files => run(files, process.env.CI ? verbose : concise))
   .then(({ passed, failed }) => failed ? process.exit(1) : process.exit(0))
   .catch(err => {

--- a/cli.mjs
+++ b/cli.mjs
@@ -2,8 +2,10 @@
 import run from './runner.mjs'
 import concise from './report-concise.mjs'
 import verbose from './report-verbose.mjs'
+import crawl from './crawler.mjs'
 
-run('./test/', process.env.CI ? verbose : concise)
+crawl('./test/')
+  .then(files => run(files, process.env.CI ? verbose : concise))
   .then(({ passed, failed }) => failed ? process.exit(1) : process.exit(0))
   .catch(err => {
     process.stderr.write(err.toString())

--- a/crawler.mjs
+++ b/crawler.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs'
+import util from 'util'
+import path from 'path'
+
+const readdir = util.promisify(fs.readdir)
+
+export default function crawl (dir) {
+  return readdir(dir)
+    .then(files => files.map(file => path.resolve(dir, file)))
+}

--- a/example.mjs
+++ b/example.mjs
@@ -1,5 +1,14 @@
 import run from './runner.mjs'
+import crawl from './crawler.mjs'
 import concise from './report-concise.mjs'
 import verbose from './report-verbose.mjs'
 
-run('./test/fixtures/', concise).then(() => run('./test/fixtures/', verbose))
+const fixtures = crawl('./test/fixtures/')
+
+fixtures
+  .then(fixtures => {
+    return run(fixtures, concise)
+  })
+  .then(fixtures => {
+    return run(fixtures, verbose)
+  })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "files": [
     "batch-promise.mjs",
     "cli.mjs",
+    "crawler.mjs",
     "oletus.mjs",
     "report-concise.mjs",
     "report-verbose.mjs",

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -1,4 +1,5 @@
 import run from '../runner.mjs'
+import crawl from '../crawler.mjs'
 import assert from 'assert'
 
 function fail (e) {
@@ -6,7 +7,8 @@ function fail (e) {
   process.exit(1)
 }
 
-run('./test/fixtures/')
+crawl('./test/fixtures/')
+  .then(run)
   .then(({ passed, failed }) => {
     assert.strict.equal(passed, 6)
     assert.strict.equal(failed, 4)


### PR DESCRIPTION
# Motivation

I'm in the process of migrating from one test runner to Oletus, and I want to do it gradually. In order to do so, I want Oletus to run on a subset of all the files I have in `./test`. This PR adds a feature where users can supply their own list of test files to the Oletus CLI, like: `oletus test/file1.mjs test/file2.mjs`. If no files are specified, we fall back to crawling the `./test/` directory.

This feature is not only useful for my specific case though. It'll also help users who have their tests in other places, eg: `oletus src/**/*.test.mjs`, and users who have their tests in nested directories.

# Changes

- The first commit is a pure refactor which moves the directory crawling logic outside of the test running logic.
- The second commit builds on this to make the directory crawling part optional in the CLI, adding the provided list of files as a second option.