### PR TITLE
Properly pass the fixtures in the example module

### DIFF
--- a/example.mjs
+++ b/example.mjs
@@ -6,8 +6,10 @@ import verbose from './report-verbose.mjs'
 const fixtures = crawl('./test/fixtures/')
 
 fixtures
-  .then(fixtures => {
-    return run(fixtures, concise)
+  .then(async fixtures => {
+    await run(fixtures, concise)
+
+    return fixtures
   })
   .then(fixtures => {
     return run(fixtures, verbose)


### PR DESCRIPTION
Fixes `npm run example` only running the `concise` reporter. The fixtures were never passed in to the `verbose` reporter, as `run` doesn't pass-through its' inputs.