### PR TITLE
Add detection of forever-pending tests

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -10,7 +10,10 @@ const eventualFiles = process.argv.length > 2
 
 eventualFiles
   .then(files => run(files, process.env.CI ? verbose : concise))
-  .then(({ passed, failed, crashed }) => (failed + crashed > 0) ? process.exit(1) : process.exit(0))
+  .then(({ passed, failed, crashed, pending }) => (failed + crashed + pending > 0)
+    ? process.exit(1)
+    : process.exit(0)
+  )
   .catch(err => {
     process.stderr.write(err.toString())
     process.exit(1)

--- a/report-concise.mjs
+++ b/report-concise.mjs
@@ -1,6 +1,6 @@
 import perfHooks from 'perf_hooks'
 
-export default function concise ({ type, timestamp, passed, failed, payload }) {
+export default function concise ({ type, timestamp, passed, failed, pending, payload }) {
   let str = '\r'
 
   switch (type) {
@@ -12,6 +12,10 @@ export default function concise ({ type, timestamp, passed, failed, payload }) {
       if (payload.stderr.length > 0) {
         str += `\x1b[33;1m⚠ ${payload.file} had output on stderr:\x1b[0m`
         str += `\n\x1b[2m${Buffer.concat(payload.stderr).toString('utf8')}\x1b[0m\n`
+      }
+      if (payload.running.size > 0) {
+        str += `\x1b[31m✖ ${payload.file} exited with ${payload.running.size} test(s) still pending:\x1b[0m`
+        str += `\n${Array.from(payload.running.values()).map(title => `    \x1b[2m- ${title}\x1b[0m\n`).join('')}\n`
       }
       break
 
@@ -26,7 +30,9 @@ export default function concise ({ type, timestamp, passed, failed, payload }) {
 
   str += `\x1b[30m\x1b[42m ${passed} passed \x1b[0m`
   str += `\x1b[30m\x1b[41m ${failed} failed \x1b[0m`
+  str += `\x1b[30m\x1b[43m ${pending} pending \x1b[0m`
   str += `\x1b[36m in ${((perfHooks.performance.now() - timestamp) / 1000).toFixed(3)}s\x1b[0m`
+  str += ' '.padEnd(5)
 
   if (type === 'Completion') str += '\n'
 

--- a/report-verbose.mjs
+++ b/report-verbose.mjs
@@ -1,21 +1,25 @@
 import perfHooks from 'perf_hooks'
 
-export default function verbose ({ type, timestamp, passed, failed, payload }) {
+export default function verbose ({ type, timestamp, passed, failed, pending, payload }) {
   let str = '\r'
 
   switch (type) {
     case 'Pass':
-      str += `\x1b[32m✔\x1b[0m ${payload.file.substr(0, payload.file.indexOf('.'))} \x1b[2m›\x1b[0m ${payload.title.padEnd(40)}\n`
+      str += `\x1b[32m✔\x1b[0m ${payload.file.substr(0, payload.file.indexOf('.'))} \x1b[2m›\x1b[0m ${payload.title.padEnd(45)}\n`
       break
 
     case 'Fail':
-      str += `${' '.padEnd(40)}\n\x1b[31m\x1b[1m✖ ${payload.title}\x1b[0m\n\x1b[2m${payload.location}\x1b[0m\n${payload.message}\n\n`
+      str += `${' '.padEnd(45)}\n\x1b[31m\x1b[1m✖ ${payload.title}\x1b[0m\n\x1b[2m${payload.location}\x1b[0m\n${payload.message}\n\n`
       break
 
     case 'File':
       if (payload.stderr.length > 0) {
         str += `\x1b[33;1m⚠ ${payload.file} had output on stderr:\x1b[0m`
         str += `\n\x1b[2m${Buffer.concat(payload.stderr).toString('utf8')}\x1b[0m\n`
+      }
+      if (payload.running.size > 0) {
+        str += `\x1b[31m✖ ${payload.file} exited with ${payload.running.size} test(s) still pending:\x1b[0m`
+        str += `\n${Array.from(payload.running.values()).map(title => `    \x1b[2m- ${title}\x1b[0m\n`).join('')}\n`
       }
       break
 
@@ -28,13 +32,15 @@ export default function verbose ({ type, timestamp, passed, failed, payload }) {
     }
 
     case 'Completion':
-      str += `${' '.padEnd(40)}\n`
+      str += `${' '.padEnd(45)}\n`
       break
   }
 
   str += `\x1b[30m\x1b[42m ${passed} passed \x1b[0m`
   str += `\x1b[30m\x1b[41m ${failed} failed \x1b[0m`
+  str += `\x1b[30m\x1b[43m ${pending} pending \x1b[0m`
   str += `\x1b[36m in ${((perfHooks.performance.now() - timestamp) / 1000).toFixed(3)}s\x1b[0m`
+  str += ' '.padEnd(5)
 
   if (type === 'Completion') str += '\n'
 

--- a/report.mjs
+++ b/report.mjs
@@ -1,19 +1,19 @@
-export const Pass = (timestamp, passed, failed, payload) => ({
-  type: 'Pass', timestamp, passed, failed, payload
+export const Pass = (timestamp, passed, failed, pending, payload) => ({
+  type: 'Pass', timestamp, passed, failed, pending, payload
 })
 
-export const Fail = (timestamp, passed, failed, payload) => ({
-  type: 'Fail', timestamp, passed, failed, payload
+export const Fail = (timestamp, passed, failed, pending, payload) => ({
+  type: 'Fail', timestamp, passed, failed, pending, payload
 })
 
-export const File = (timestamp, passed, failed, payload) => ({
-  type: 'File', timestamp, passed, failed, payload
+export const File = (timestamp, passed, failed, pending, payload) => ({
+  type: 'File', timestamp, passed, failed, pending, payload
 })
 
-export const Crash = (timestamp, passed, failed, payload) => ({
-  type: 'Crash', timestamp, passed, failed, payload
+export const Crash = (timestamp, passed, failed, pending, payload) => ({
+  type: 'Crash', timestamp, passed, failed, pending, payload
 })
 
-export const Completion = (timestamp, passed, failed, payload) => ({
-  type: 'Completion', timestamp, passed, failed, payload
+export const Completion = (timestamp, passed, failed, pending, payload) => ({
+  type: 'Completion', timestamp, passed, failed, pending, payload
 })

--- a/test/fixtures/crash.mjs
+++ b/test/fixtures/crash.mjs
@@ -1,0 +1,7 @@
+import test from '../../oletus.mjs'
+
+test ('never settles', () => new Promise (() => {}));
+
+setTimeout(() => {
+  throw new Error ('I like turtles.');
+}, 10);

--- a/test/fixtures/pending.mjs
+++ b/test/fixtures/pending.mjs
@@ -1,0 +1,3 @@
+import test from '../../oletus.mjs'
+
+test ('never settles', () => new Promise (() => {}));

--- a/test/run.mjs
+++ b/test/run.mjs
@@ -9,8 +9,10 @@ function fail (e) {
 
 crawl('./test/fixtures/')
   .then(run)
-  .then(({ passed, failed }) => {
+  .then(({ passed, failed, pending, crashed }) => {
     assert.strict.equal(passed, 6)
     assert.strict.equal(failed, 4)
+    assert.strict.equal(pending, 1)
+    assert.strict.equal(crashed, 1)
   })
   .catch(e => fail(e))

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -11,8 +11,8 @@ function resolveAfter (time) {
 }
 
 test('equal pass', t => t.equal('a', 'a'))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, true)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'passed')
     assert.strict.equal(title, 'equal pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
@@ -20,8 +20,8 @@ test('equal pass', t => t.equal('a', 'a'))
   .catch(e => fail(e))
 
 test('equal fail', t => t.equal('a', 'b'))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, false)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'failed')
     assert.strict.equal(title, 'equal fail')
     assert.strict.equal(location, '/test/test.mjs:22')
     assert.strict.equal(typeof message, 'string')
@@ -29,8 +29,8 @@ test('equal fail', t => t.equal('a', 'b'))
   .catch(e => fail(e))
 
 test('ok pass', t => t.ok(true))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, true)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'passed')
     assert.strict.equal(title, 'ok pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
@@ -38,8 +38,8 @@ test('ok pass', t => t.ok(true))
   .catch(e => fail(e))
 
 test('ok fail', t => t.ok(false))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, false)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'failed')
     assert.strict.equal(title, 'ok fail')
     assert.strict.equal(location, '/test/test.mjs:40')
     assert.strict.equal(message.split('\n').length, 1)
@@ -47,8 +47,8 @@ test('ok fail', t => t.ok(false))
   .catch(e => fail(e))
 
 test('deepEqual pass', t => t.deepEqual({ a: { b: 42 } }, { a: { b: 42 } }))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, true)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'passed')
     assert.strict.equal(title, 'deepEqual pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
@@ -56,8 +56,8 @@ test('deepEqual pass', t => t.deepEqual({ a: { b: 42 } }, { a: { b: 42 } }))
   .catch(e => fail(e))
 
 test('deepEqual fail', t => t.deepEqual({ a: { b: 42 } }, { a: { B: 42 } }))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, false)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'failed')
     assert.strict.equal(title, 'deepEqual fail')
     assert.strict.equal(location, '/test/test.mjs:58')
     assert.strict.equal(typeof message, 'string')
@@ -65,8 +65,8 @@ test('deepEqual fail', t => t.deepEqual({ a: { b: 42 } }, { a: { B: 42 } }))
   .catch(e => fail(e))
 
 test('async pass', async t => t.equal(await resolveAfter(500), 'resolved'))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, true)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'passed')
     assert.strict.equal(title, 'async pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
@@ -74,8 +74,8 @@ test('async pass', async t => t.equal(await resolveAfter(500), 'resolved'))
   .catch(e => fail(e))
 
 test('async fail', async t => t.equal(await resolveAfter(777), ''))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, false)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'failed')
     assert.strict.equal(title, 'async fail')
     assert.strict.ok(location.includes('/test/test.mjs:76:33'))
     assert.strict.equal(typeof message, 'string')
@@ -83,8 +83,8 @@ test('async fail', async t => t.equal(await resolveAfter(777), ''))
   .catch(e => fail(e))
 
 test('promise pass', t => resolveAfter(100).then(result => t.equal(result, 'resolved')))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, true)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'passed')
     assert.strict.equal(title, 'promise pass')
     assert.strict.equal(location, '')
     assert.strict.equal(message, '')
@@ -92,8 +92,8 @@ test('promise pass', t => resolveAfter(100).then(result => t.equal(result, 'reso
   .catch(e => fail(e))
 
 test('promise fail', t => resolveAfter(100).then(result => t.equal(result, '')))
-  .then(({ didPass, title, location, message }) => {
-    assert.strict.equal(didPass, false)
+  .then(({ status, title, location, message }) => {
+    assert.strict.equal(status, 'failed')
     assert.strict.equal(title, 'promise fail')
     assert.strict.ok(location.includes('/test/test.mjs:94:62'))
     assert.strict.equal(typeof message, 'string')


### PR DESCRIPTION
A forever pending test can occur when a Promise is returned
that never calls its reject or resolve callbacks.

When this happens, the Promise is garbage collected and the
process exits gracefully.

To the Oletus test runner this makes it look like there never
even was a test to begin with, which means Oletus will not
report on the fact that you tried to run a test, but it never
completed.

This commit makes it so the Oletus test runner receives
messages about tests starting on top of tests ending, so it
can keep track of all tests that haven't ended yet, and report
on them when the process exits prematurely.

----

```console
$ node --experimental-modules --no-warnings ./cli.mjs test/fixtures/pending.mjs
```

![latest-screenshot](https://user-images.githubusercontent.com/1217745/75455856-1ca9e580-597a-11ea-973c-072137412168.png)

- A new field "pending" was added to the stats bar.
- Tests that were pending when a child process exits are now considered "failed", and the list of pending tests is included in the report.
- When a child process exits with a non-zero exit code (#8), the crash report takes prevalence over any pending tests that might've been remaining.

Fixes #11 

----

:warning: If merged, you might want to release this under a major version bump. These changes make it so some test suites that would previously have completed without failure, now fail, possibly breaking people's builds.