### PR TITLE
Improve documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,15 @@
 
 A zero configuration, zero dependency test runner for ECMAScript Modules—made specifically for getting started quick. Painless migration to the bigger guns if you end up needing them.
 
-## Test Syntax
+## Features
+
+- **Native ECMAScript Modules support**.
+- **Simple**: No configuration. No test timeouts. No global scope pollution. No runner hooks. No compilation step. No source maps.
+- **Super fast**: Asynchronous tests run concurrently, individual modules run concurrently using multiple CPUs, no overhead from compilation.
+
+## Usage
+
+### Test Syntax
 
 ```js
 import test from 'oletus'
@@ -13,58 +21,59 @@ import test from 'oletus'
 test('arrays are equal', t => {
   t.deepEqual([1, 2], [1, 2])
 })
-```
 
-## Usage
-
-### Add oletus to your project
-
-Install it with npm:
-```bash
-npm install --save-dev oletus
-```
-Add the test script to your `package.json`, using the native [--experimental-modules](https://nodejs.org/api/esm.html#esm_ecmascript_modules):
-```json
-  "scripts": {
-    "test": "npx -n='--experimental-modules --no-warnings' oletus"
-  },
-```
-Alternatively, you can use the [esm](https://github.com/standard-things/esm#esm) package for wider support:
-```json
-  "scripts": {
-    "test": "npx -n='-r esm' oletus"
-  },
-```
-
-### Create the tests
-
-Write your test modules in a `/test/` directory:
-```js
-import test from 'oletus'
-
-test('foo', t => {
-  t.ok(true)
-})
-
+// you can use async functions or otherwise return Promises
 test('bar', async t => {
   const bar = Promise.resolve('bar')
-
   t.equal(await bar, 'bar')
 })
 ```
 
----
+### Add oletus to your project
 
-#### Alternate test locations
+Install it with npm:
 
-It's also possible to run tests that match a pattern passed in as a command-line argument.
 ```bash
-oletus src/**/*.test.mjs
+npm install --save-dev oletus
 ```
 
----
+Modify the `test` script in your `package.json`:
 
-### `npm test` away!
+```json
+{
+  "test": "oletus"
+}
+```
+
+### Older versions of Node
+
+On Node 12 you need to pass [`--experimental-modules`](https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_enabling):
+
+```json
+{
+  "test": "node --experimental-modules --no-warnings -- ./node_modules/.bin/oletus"
+}
+```
+
+For even older Node versions, use [esm](https://github.com/standard-things/esm#esm):
+
+```json
+{
+  "test": "node -r esm -- ./node_modules/.bin/oletus"
+}
+```
+
+### Test locations
+
+By default, Oletus runs all files that exist in your `/test` directory.
+Alternatively, you can specify a list of files to run. Note that the glob
+pattern in the example below is handled by your shell, not by Oletus.
+
+```json
+{
+  "test": "oletus test.js src/**/*.test.mjs"
+}
+```
 
 ## Reporters
 
@@ -72,11 +81,102 @@ Oletus has a *concise reporter* on local runs and a *verbose reporter* on CI env
 
 <img src="./oletus-reporters.png">
 
-
 ## API
 
-### `test(title, implementation)`
-The imported `test` is an *async function* that expects the `title` and `implementation` of the test to be passed in as arguments. The implementation has a single parameter (`t`, for example) that gets passed the [strict node assertion](https://nodejs.org/api/assert.html#assert_strict_mode) module.
+### `test :: (String, StrictAssertModule -> Promise?) -> Promise TestResult`
+
+The `test` function, which is the default export from Oletus, takes the following arguments:
+
+- `title`: A String describing the test case.
+- `implementation`: A function that runs your assertions. The implementation has a single parameter (`t`, for example) that gets passed the [strict node assertion](https://nodejs.org/api/assert.html#assert_strict_mode) module. If this function returns a Promise, Oletus awaits the result to know if your test
+passes. Otherwise the test is assumed to pass if it doesn't throw.
+
+The return value from `test` function is a Promise of an object with the following shape `{ didPass, title, location, message }`. Note that for most cases, you don't actually need to do anything with the returned Promise, but for reference, this is what its resolution value looks like:
+
+- `didPass`: A boolean to indicate whether the test has passed.
+- `title`: The title of the test.
+- `location`: The stack trace for the failure reason, or an empty string if `didPass` was `true`.
+- `message` The failure reason, or an empty string if `didPass` was `true`.
+
+## Examples
+
+### Code coverage
+
+Oletus works great together with [`c8`](https://github.com/bcoe/c8). C8 is a tool for running code coverage natively using the V8 built-in code coverage functionality. The reason this pairs well with Oletus is because with Oletus, you tend to run your ESM code natively, and no other coverage tools can deal with that. Set it up like this:
+
+```json
+{
+  "test": "c8 oletus test.js src/**/*.test.mjs"
+}
+```
+
+### Using Oletus for testing CommonJS modules
+
+Your codebase doesn't need to be written as EcmaScript 6 modules to use Oletus. The only part of your code that really needs to contain es6 modules is your tests themselves. But you're free to import CommonJS modules via [CommonJS Interoperability](https://nodejs.org/dist/latest/docs/api/esm.html#esm_interoperability_with_commonjs):
+
+```js
+import test from 'oletus'
+import myCJSModule from '../src/index.js'
+
+test ('my export', t => {
+  t.equals (myCJSModule.myExportedAnswer, 42)
+})
+```
+
+### Running tests in sequence instead of parallely
+
+Because the `test` function returns a Promise, it's quite straight-forward to
+modify the execution order or rewire things any other way:
+
+```js
+const runTests = async () => {
+  await test('foo', async t => {
+    const foo = Promise.resolve('foo')
+    t.equal(await foo, 'foo')
+  })
+
+  await test('bar', async t => {
+    const bar = Promise.resolve('bar')
+    t.equal(await bar, 'bar')
+  })
+}
+
+runTests()
+```
+
+### Setup and teardown
+
+Because the `test` function returns a Promise, it's quite straight-forward to
+wrap a test in setup and teardown logic:
+
+```js
+const testWithDatabase = async (title, implementation) => {
+  const database = await setupDatabase()
+  await test (title, t => implementation(t, database))
+  await teardownDatabase()
+}
+
+testWithDatabase ('has users', async (t, database) => {
+  const users = await database.queryUsers()
+  t.equals (users, [{ name: 'bob' }])
+})
+```
+
+### Programmatic use
+
+Besides the CLI, there's also an interface for programmatic use:
+
+```js
+import run from 'oletus/runner.mjs'
+import concise from 'oletus/report-concise.mjs'
+
+const { passed, failed, crashed } = await run(['test/index.mjs'], concise)
+
+console.log (
+  '%s tests passed, %s tests failed, and %s files crashed',
+  passed, failed, crashed
+)
+```
 
 ## Author
 


### PR DESCRIPTION
# Motivation

I am going to present this library to my colleagues at work. I decided
that instead of writing this all down in a presentation, I might as well
simply update the library documentation, and allow others to benefit.

# Changes

- Restructure the document a little bit
- Update setup steps for node 13 and up
- Remove mention of 'npx', as it might make users think this is required
- Add list of features
- Add several usage examples for a variety of cases