### PR TITLE
Fix: Publish TypeScript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "example": "node --experimental-modules --no-warnings example.mjs"
   },
   "files": [
+    "*.d.ts",
     "batch-promise.mjs",
     "cli.mjs",
     "crawler.mjs",


### PR DESCRIPTION
Hi again!

I tested the new release and unfortunately we miss to include the added files in package.json files entry. I didn't notice this during my testing process because I was using a symlink... my bad.

This PR fix this issue.