### PR TITLE
Remove faulty assertion-message-boilerplate-reduction feature

### DIFF
--- a/oletus.mjs
+++ b/oletus.mjs
@@ -84,11 +84,6 @@ export default async function test (title, implementation) {
     status = 'failed' // any uncaught error in `implementation` counts as a fail
     location = getLocation(5, test) || extractTraceFallback(e.stack)
     message = e.message
-
-    // Omit the verbose assertion boilerplate from reporting.
-    if (e instanceof AssertionError) {
-      message = e.message.split('\n').slice(2).join('\n')
-    }
   }
 
   // Report the status of a completed test back to the `runner`...


### PR DESCRIPTION
This feature aims to remove the following boilerplate from assertion
errors when reporting them:

    Expected values to be strictly deep-equal:
    + actual - expected

However, when a custom assertion error is used, for example:

    assert.deepStrictEqual(1, 2, 'One should have been two');

The reported error also has its first two lines, which is now the entire
error message, removed.

Since the feature in question is rather minor, my initial tendency is
just to remove it.