### PR TITLE
Fix stack trace in recent Node versions

### DIFF
--- a/oletus.mjs
+++ b/oletus.mjs
@@ -14,7 +14,9 @@ function customPrepareStackTrace (e, stack) {
     .filter(frame => !frame.isNative())
     .filter(frame => {
       const file = frame.getFileName()
-      return file && !file.startsWith('internal/')
+      return file &&
+        !file.startsWith('internal/') &&
+        !file.startsWith('node:internal/')
     })
     .map(frame => `${stripCwd(frame.getFileName())}:${frame.getLineNumber()}`)
     .join('\n')


### PR DESCRIPTION
Hi there :)

oletus removes node's internal stacktrace frames.
To do this, it removes frames starting with `internal/`.

Recent versions of Node add a `node:` prefix to internal frames.
Frames starting with `node:internal/` are now removed.